### PR TITLE
Remove unused Class1 from HerfyBackend.Infrastructure

### DIFF
--- a/src/HerfyBackend.Infrastructure/Class1.cs
+++ b/src/HerfyBackend.Infrastructure/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace HerfyBackend.Infrastructure
-{
-    public class Class1
-    {
-
-    }
-}


### PR DESCRIPTION
The `Class1` class, along with its namespace declaration (`HerfyBackend.Infrastructure`) and empty class body, was entirely removed from `Class1.cs`. This cleanup eliminates unused code and improves maintainability.